### PR TITLE
Add Ollama and OpenHands services to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,59 @@ services:
     working_dir: /projects
     ports:
       - 8503:8503
+    networks:
+      - openhands_net
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_models:/root/.ollama
+      - ./Modelfile:/app/Modelfile:ro
+    networks:
+      - openhands_net
+    environment:
+      OLLAMA_HOST: 0.0.0.0
+    entrypoint:
+      [
+        "/bin/sh",
+        "-c",
+        "ollama serve & sleep 5 && ollama create mymodel -f /app/Modelfile && wait",
+      ]
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    restart: unless-stopped
+
+  openhands:
+    image: docker.all-hands.dev/all-hands-ai/openhands:latest
+    container_name: openhands-app
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./workspace:/workspace
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - openhands_net
+    environment:
+      LLM_MODEL: ollama/mymodel
+      LLM_API_KEY: dummy
+      LLM_BASE_URL: http://ollama:11434
+      SANDBOX_VOLUMES: ./workspace:/workspace
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
+    depends_on:
+      ollama:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  ollama_models:
+
+networks:
+  openhands_net:
+    driver: bridge


### PR DESCRIPTION
### Motivation
- Add an Ollama model server and OpenHands app to the existing compose so OpenHands can use a local Ollama model and the existing `llm` service can share the same network.
- Provide persistent model storage and automatic model creation from a `Modelfile` to simplify local development and reproducible setups.
- Ensure OpenHands waits for Ollama to become healthy before starting to avoid startup race conditions.

### Description
- Attached the existing `llm` service to a new `openhands_net` network and added an `ollama` service using `ollama/ollama:latest` with port `11434`, a persistent `ollama_models` volume, a read-only `./Modelfile` mount, an entrypoint that runs `ollama serve` then creates `mymodel`, a healthcheck using `ollama list`, and `restart: unless-stopped`.
- Added an `openhands` service using `docker.all-hands.dev/all-hands-ai/openhands:latest` with ports, `./workspace` and `/var/run/docker.sock` mounts, environment variables `LLM_MODEL`, `LLM_BASE_URL`, `SANDBOX_VOLUMES`, and `GITHUB_TOKEN`, and `depends_on` configured to wait for the `ollama` service to be healthy.
- Declared the `ollama_models` volume and the `openhands_net` bridge network in the compose file.

### Testing
- Attempted `docker compose config` to validate the compose file, but the command failed because the environment lacks the `docker` binary, so runtime validation could not be completed.
- Inspected the updated file with `cat -n docker-compose.yml` to verify the new services and configuration structure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172c7a6230832dac80b7ed681cebcc)