### PR TITLE
Add standalone Ollama multi-turn chat CLI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,24 @@ https://huggingface.co/models?library=gguf&sort=likes
 
 - https://weather.tsukumijima.net/
 - https://easy2.connpass.com/
+
+## Standalone Ollama Chat App
+
+既存のStreamlitアプリとは独立して、Ollama向けのCLIアプリを追加しました。
+
+### セットアップ
+
+```bash
+pip install -r requirements.txt
+```
+
+### 実行
+
+```bash
+python ollama_chat_app.py --model qwen3:8b --window-size 10 --num-predict 2048
+```
+
+- `/exit` または `quit` で終了できます。
+- 会話履歴は `messages` リストとして保持します。
+- コンテキストは「system + 直近Nターン」のみを送信します。
+- `stream=True` でトークンを逐次表示します。

--- a/ollama_chat_app.py
+++ b/ollama_chat_app.py
@@ -1,0 +1,106 @@
+"""Standalone multi-turn chat CLI for Ollama.
+
+Usage:
+  python ollama_chat_app.py --model qwen3:8b --window-size 10
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import ollama
+
+DEFAULT_SYSTEM_PROMPT = "あなたは親切なアシスタントです。日本語で回答してください。"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="OllamaマルチターンチャットCLI")
+    parser.add_argument("--model", default="qwen3:8b", help="利用するOllamaモデル名")
+    parser.add_argument(
+        "--window-size",
+        type=int,
+        default=10,
+        help="文脈として渡す直近ターン数（systemメッセージを除く）",
+    )
+    parser.add_argument(
+        "--num-predict",
+        type=int,
+        default=2048,
+        help="1回の応答で生成する最大トークン数",
+    )
+    parser.add_argument(
+        "--system-prompt",
+        default=DEFAULT_SYSTEM_PROMPT,
+        help="初期システムプロンプト",
+    )
+    return parser
+
+
+def build_context(conversation: list[dict[str, str]], window_size: int) -> list[dict[str, str]]:
+    system_message = conversation[:1]
+    recent_messages = conversation[-(window_size * 2) :] if window_size > 0 else []
+    return system_message + recent_messages
+
+
+def stream_chat(
+    conversation: list[dict[str, str]],
+    *,
+    model: str,
+    window_size: int,
+    num_predict: int,
+) -> str:
+    context = build_context(conversation, window_size)
+    response = ollama.chat(
+        model=model,
+        messages=context,
+        stream=True,
+        options={"num_predict": num_predict},
+    )
+
+    partial_message = ""
+    print("アシスタント: ", end="", flush=True)
+    for chunk in response:
+        token = chunk["message"]["content"]
+        print(token, end="", flush=True)
+        partial_message += token
+    print()
+    return partial_message
+
+
+def run_chat(model: str, window_size: int, num_predict: int, system_prompt: str) -> None:
+    conversation: list[dict[str, str]] = [{"role": "system", "content": system_prompt}]
+
+    print("Ollamaマルチターンチャットを開始します。終了するには /exit を入力してください。")
+    print(f"model={model}, window_size={window_size}, num_predict={num_predict}")
+
+    while True:
+        user_message = input("あなた: ").strip()
+        if not user_message:
+            continue
+        if user_message in {"/exit", "exit", "quit", "/quit"}:
+            print("チャットを終了します。")
+            break
+
+        conversation.append({"role": "user", "content": user_message})
+        assistant_message = stream_chat(
+            conversation,
+            model=model,
+            window_size=window_size,
+            num_predict=num_predict,
+        )
+        conversation.append({"role": "assistant", "content": assistant_message})
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    run_chat(
+        model=args.model,
+        window_size=args.window_size,
+        num_predict=args.num_predict,
+        system_prompt=args.system_prompt,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ nvidia-nccl-cu12==2.27.3
 nvidia-nvjitlink-cu12==12.8.93
 nvidia-nvtx-cu12==12.8.90
 orjson==3.11.6
+ollama==0.6.0
 packaging==24.2
 pandas==2.3.2
 pillow==12.2.0


### PR DESCRIPTION
### Motivation
- Provide an independent, lightweight CLI application to prototype and use Ollama for multi-turn chat without touching the existing Streamlit app.
- Support a simple streaming UX and controllable context window so the app can demonstrate `messages`-based multi-turn chat with Ollama.

### Description
- Add `ollama_chat_app.py` which implements a CLI with argument parsing, `build_context`, `stream_chat`, and `run_chat` to keep conversation history and stream tokens from `ollama.chat`.
- Update `README.md` to include a `Standalone Ollama Chat App` section with setup and usage instructions (`python ollama_chat_app.py --model qwen3:8b --window-size 10 --num-predict 2048`).
- Add `ollama==0.6.0` to `requirements.txt` so the new CLI can be installed via `pip install -r requirements.txt`.
- Ensure the new script is syntactically valid and ready to run as a standalone tool.

### Testing
- Ran `python -m py_compile ollama_chat_app.py` and compilation succeeded.
- No additional automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17333a572c832d8b863a0450726f37)